### PR TITLE
Docker image for frontend

### DIFF
--- a/.entrypoint.sh
+++ b/.entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i "s|http://localhost:8000|$CACAO_BACKEND_URL|g" /var/www/html/build/app.js
+nginx -g "daemon off;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:4
+
+RUN apt-get update -qq && \
+    apt-get install -y nginx
+EXPOSE 80
+
+ADD . /app
+WORKDIR /app
+RUN make install && \
+    npm rebuild node-sass && \
+    make build && \
+    cp *.html /var/www/html && \
+    cp -Rv css /var/www/html/ && \
+    cp -Rv build/ /var/www/html/ && \
+    cp -Rv partials/ /var/www/html && \
+    rm -rf build
+
+ENV CACAO_BACKEND_URL http://localhost:8000
+
+CMD ["/app/.entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ install:
 	npm install
 
 build:
-	./node_modules/.bin/webpack  --progress --colors --devtool source-map
+	./node_modules/.bin/webpack  --progress --colors
 
 run:
 	@echo "**************************************************"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "angular-gravatar": "^0.4.2",
     "angular-jwt": "0.0.9",
     "angular-material": "1.1.0-rc.5",
-    "angular-material-data-table": "git+ssh://git@github.com/erasche/md-data-table.git",
+    "angular-material-data-table": "git+https://github.com/erasche/md-data-table.git",
     "angular-material-icons": "^0.7.1",
     "angular-messages": "1.5.5",
     "angular-resource": "1.5.5",


### PR DESCRIPTION
This allows you to build a docker container for the frontend, which is how we'll deploy it.

Building this container:

```
docker build -t cacao-frontend .
```

Running it:

```
docker run -it -p 10000:80 -e CACAO_BACKEND_URL=http://localhost:8000 cacao-frontend
```

as you can see with the `CACAO_BACKEND_URL` there, the backend address is configurable for when we deploy to production, so we can change that URL as needed. The `-p 10000:80` binds the external port 10000, i.e. on your computer, to the internal container port of 80.
